### PR TITLE
CAR-1822 Add -Wno-format flag to at_boost_execution_monitor target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ target_compile_definitions(at_boost_execution_monitor
 )
 
 set_target_properties(at_boost_execution_monitor
-   PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations"
+   PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations -Wno-format"
 )
 
 set(BOOST_UNITTEST_SOURCES


### PR DESCRIPTION
https://airtime.atlassian.net/browse/CAR-1822

This target (part of boost unit tests) is failing on 32-bit debug builds, adding this flag disables the format warning so that it builds.