### PR TITLE
 TEC-1340 boost use march = native only for linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ set_target_properties(at_boost_log
    PROPERTIES COMPILE_FLAGS "-ftemplate-depth-1024 -Wno-deprecated-declarations"
 )
 
-if (NOT IOS AND NOT ANDROID)
+if (NOT IOS AND NOT ANDROID AND NOT OSX)
   set_property(TARGET at_boost_log APPEND_STRING PROPERTY COMPILE_FLAGS " -march=native")
 endif()
 


### PR DESCRIPTION
TEC-1480 Build Media Components with M1 version of Homebrew
When 'march = native' is used on M1 Mac it generates the below error in Xcode for boost log:

```
error: unknown target CPU 'vortex'
note: valid target CPU values are: nocona, core2, penryn, bonnell, atom, silvermont, slm, goldmont, goldmont-plus, tremont, nehalem, corei7, westmere, sandybridge, corei7-avx, ivybridge, core-avx-i, haswell, core-avx2, broadwell, skylake, skylake-avx512, skx, cascadelake, cooperlake, cannonlake, icelake-client, icelake-server, tigerlake, sapphirerapids, alderlake, knl, knm, k8, athlon64, athlon-fx, opteron, k8-sse3, athlon64-sse3, opteron-sse3, amdfam10, barcelona, btver1, btver2, bdver1, bdver2, bdver3, bdver4, znver1, znver2, znver3, x86-64, x86-64-v2, x86-64-v3, x86-64-v4
/Users/sumitkandpal-m1/Documents/libtecate-terminal-3/build/xcode-osx/boost/libtecate.build/Debug/at_boost_log.build/Objects-normal/x86_64/attribute_set.dia:1:1: warning: Could not read serialized diagnostics file: error("Failed to open diagnostics file") (in target 'at_boost_log' from project 'libtecate')
```

Excluding setting march = native for Mac
